### PR TITLE
Restrict the version of `libz` after #19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ links = "tor"
 
 [dependencies]
 openssl-sys = "0.9"
-libz-sys = { version = "1.0", features = ["static"] }
+libz-sys = { version = "~1.1.3", features = ["static"] }
 lzma-sys = { version = "0.1", optional = true }
 zstd-sys = { version = "1.4", optional = true }
 


### PR DESCRIPTION
Ensure that we don't accidentally use an older version of libz now that
we've changed our paths to match theirs in >=1.1.3